### PR TITLE
[PLA-1662] Make decoder image from dockerhub to work on macOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "${REDIS_EXTERNAL_PORT}:6379"
 
   decoder:
+    platform: linux/amd64
     image: enjin/platform-decoder:latest
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Specified the platform for the `decoder` service in `docker-compose.yml` to ensure compatibility and predictability in deployments.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Specify Platform for Decoder Service in Docker Compose</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml
<li>Added <code>platform: linux/amd64</code> specification for the <code>decoder</code> service.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform/pull/35/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

