### PR TITLE
DockerHub image to support multi-platform

### DIFF
--- a/.github/workflows/push-image-to-dockerhub.yml
+++ b/.github/workflows/push-image-to-dockerhub.yml
@@ -7,22 +7,28 @@ on:
     types: [created]
 
 jobs:
-  push:
+  docker:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Login, build, tag, and push image to DockerHub
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_API_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_API_TOKEN  }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
         env:
-          DOCKERHUB_API_USERNAME: ${{ secrets.DOCKERHUB_API_USERNAME }}
-          DOCKERHUB_API_TOKEN: ${{ secrets.DOCKERHUB_API_TOKEN }}
           DOCKER_REPOSITORY: platform
           IMAGE_TAG: ${{ github.ref_name }}
-        run: |
-          docker login --username $DOCKERHUB_API_USERNAME --password $DOCKERHUB_API_TOKEN
-          docker build -t enjin/$DOCKER_REPOSITORY:$IMAGE_TAG -f configs/core/Dockerfile .
-          docker push enjin/$DOCKER_REPOSITORY:$IMAGE_TAG
+        with:
+          context: .
+          file: configs/core/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: enjin/$DOCKER_REPOSITORY:$IMAGE_TAG 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed the job name to better reflect its purpose.
- Integrated QEMU and Docker Buildx setup for building images for multiple platforms.
- Streamlined Docker login and push process using GitHub Actions.
- Enabled building and pushing Docker images for both `linux/amd64` and `linux/arm64` platforms.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>push-image-to-dockerhub.yml</strong><dd><code>Enhance DockerHub Workflow for Multi-Platform Support</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/push-image-to-dockerhub.yml
<li>Changed job name from <code>push</code> to <code>docker</code>.<br> <li> Added steps for setting up QEMU and Docker Buildx for multi-platform <br>builds.<br> <li> Modified Docker login and image push steps to use actions instead of <br>shell commands.<br> <li> Added multi-platform support with <code>linux/amd64,linux/arm64</code>.


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform/pull/39/files#diff-375807204432883d2fe0f02e08e633760f5802823833f872fd5e68d8b0939c6f">+20/-14</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

