### PR TITLE
[PLA-1888] Fixes vite manifest not found

### DIFF
--- a/configs/core/start.sh
+++ b/configs/core/start.sh
@@ -10,7 +10,7 @@ if [ "$role" = "ingest" ]; then
     echo "Running ingest..."
     php artisan migrate && php artisan platform:sync && php artisan platform:ingest
 elif [ "$role" = "app" ]; then
-    php artisan log-viewer:publish && php artisan platform-ui:install --route="/" --tenant="no" --skip && php artisan route:cache && php artisan view:cache
+    php artisan platform-ui:install --route="/" --tenant="no" --skip && php artisan route:cache && php artisan view:cache
     echo "Running apache..."
     exec apache2-foreground
 elif [ "$role" = "relay" ]; then


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the `php artisan log-viewer:publish` command from the `app` role section in the `configs/core/start.sh` script to fix the issue with the Vite manifest not being found.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start.sh</strong><dd><code>Remove redundant log viewer publish command in start script</code></dd></summary>
<hr>

configs/core/start.sh

<li>Removed <code>php artisan log-viewer:publish</code> command from the <code>app</code> role <br>section.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/43/files#diff-1ab5cfcfc8e032f585b6a70cb59659ea3d92417af421a27973951c09f32d90c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

