### PR TITLE
Remove platform throttle config

### DIFF
--- a/configs/core/.env
+++ b/configs/core/.env
@@ -14,7 +14,6 @@ ASSET_URL="${APP_URL}"
 BCRYPT_ROUNDS=12
 CORS_PATHS="graphql,graphql/beam,graphql/fuel-tanks,graphql/marketplace"
 
-ENJIN_PLATFORM_API_THROTTLE=false
 NETWORK=canary-matrixchain
 DECODER_CONTAINER=decoder:8090
 DAEMON_ACCOUNT=


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Removed `ENJIN_PLATFORM_API_THROTTLE` configuration from the `.env` file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env</strong><dd><code>Remove `ENJIN_PLATFORM_API_THROTTLE` configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

configs/core/.env

- Removed `ENJIN_PLATFORM_API_THROTTLE` configuration.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/45/files#diff-045a431fd6c61583298c59e88dc5a1cb77dc5530da39f727cf1e7c242be9e030">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

