### PR TITLE
[PLA-1928] Upgrade platform decoder to v1.9.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
 
   decoder:
     platform: linux/amd64
-    image: enjin/platform-decoder:v1.9.0
+    image: enjin/platform-decoder:v1.9.1
     restart: unless-stopped
     ports:
       - "${DECODER_EXTERNAL_PORT}:8090"


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the `decoder` service image version in `docker-compose.yml` from `v1.9.0` to `v1.9.1`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Upgrade `decoder` service image version in Docker Compose</code></dd></summary>
<hr>

docker-compose.yml

<li>Updated the <code>decoder</code> service image version from <code>v1.9.0</code> to <code>v1.9.1</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/46/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

