### PR TITLE
Bump docker tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "${DECODER_EXTERNAL_PORT}:8090"
 
   app:
-    image: enjin/platform:v1.9.0
+    image: enjin/platform:v1.10.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -50,7 +50,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   websocket:
-    image: enjin/platform:v1.9.0
+    image: enjin/platform:v1.10.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -66,7 +66,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   ingest:
-    image: enjin/platform:v1.9.0
+    image: enjin/platform:v1.10.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -80,7 +80,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   relay:
-    image: enjin/platform:v1.9.0
+    image: enjin/platform:v1.10.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -93,7 +93,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   beam:
-    image: enjin/platform:v1.9.0
+    image: enjin/platform:v1.10.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated Docker image tags for the `app`, `websocket`, `ingest`, `relay`, and `beam` services from `v1.9.0` to `v1.10.0`.
- Updated the Docker image tag for the `platform-decoder` service to `v1.9.1`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update Docker image tags to newer versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Updated Docker image tags for multiple services from <code>v1.9.0</code> to <code>v1.10.0</code><br> <li> Ensured consistency across services by updating the <code>platform-decoder</code> <br>image to <code>v1.9.1</code><br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/48/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

