### PR TITLE
[PLA-1993] Upgrade to platform v1.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,13 @@ services:
 
   decoder:
     platform: linux/amd64
-    image: enjin/platform-decoder:v1.10.0
+    image: enjin/platform-decoder:v2.0.1
     restart: unless-stopped
     ports:
       - "${DECODER_EXTERNAL_PORT}:8090"
 
   app:
-    image: enjin/platform:v1.10.0
+    image: enjin/platform:v1.11.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -50,7 +50,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   websocket:
-    image: enjin/platform:v1.10.0
+    image: enjin/platform:v1.11.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -66,7 +66,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   ingest:
-    image: enjin/platform:v1.10.0
+    image: enjin/platform:v1.11.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -80,7 +80,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   relay:
-    image: enjin/platform:v1.10.0
+    image: enjin/platform:v1.11.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile
@@ -93,7 +93,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   beam:
-    image: enjin/platform:v1.10.0
+    image: enjin/platform:v1.11.0
     build:
       context: .
       dockerfile: configs/core/Dockerfile


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the `platform-decoder` service image to version v2.0.1.
- Updated the `platform` service image to version v1.11.0 for `app`, `websocket`, `ingest`, `relay`, and `beam` services.
- These changes ensure that the services use the latest available images, potentially including new features and bug fixes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update Docker image versions in docker-compose configuration</code></dd></summary>
<hr>

docker-compose.yml

<li>Updated <code>platform-decoder</code> image version from v1.10.0 to v2.0.1.<br> <li> Updated <code>platform</code> image version from v1.10.0 to v1.11.0 for multiple <br>services.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/51/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

