### PR TITLE
[PLA-1994] Fixes upload to Dockerhub

### DIFF
--- a/.github/workflows/push-image-to-dockerhub.yml
+++ b/.github/workflows/push-image-to-dockerhub.yml
@@ -7,28 +7,24 @@ on:
     types: [created]
 
 jobs:
-  docker:
+  push:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_API_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_API_TOKEN  }}
-      - name: Build and push
-        uses: docker/build-push-action@v5
+      - uses: actions/checkout@v4
+
+      - name: Login, build, tag, and push image to DockerHub
         env:
+          DOCKERHUB_API_USERNAME: ${{ secrets.DOCKERHUB_API_USERNAME }}
+          DOCKERHUB_API_TOKEN: ${{ secrets.DOCKERHUB_API_TOKEN }}
           DOCKER_REPOSITORY: platform
           IMAGE_TAG: ${{ github.ref_name }}
-        with:
-          context: .
-          file: configs/core/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: enjin/$DOCKER_REPOSITORY:$IMAGE_TAG 
+        run: |
+          docker login --username $DOCKERHUB_API_USERNAME --password $DOCKERHUB_API_TOKEN
+          docker build -t enjin/$DOCKER_REPOSITORY:$IMAGE_TAG .
+          docker push enjin/$DOCKER_REPOSITORY:$IMAGE_TAG
+          docker tag enjin/$DOCKER_REPOSITORY:$IMAGE_TAG enjin/$DOCKER_REPOSITORY:latest
+          docker push enjin/$DOCKER_REPOSITORY:latest


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- The GitHub Actions workflow for pushing Docker images to DockerHub has been simplified by consolidating multiple steps into a single script.
- The job name has been changed from `docker` to `push`, and permissions have been updated to include `id-token: write` and `contents: read`.
- The workflow now directly logs into DockerHub, builds, tags, and pushes the Docker image in one step, removing the need for separate setup actions for QEMU and Buildx.
- The image is tagged with both the branch name and `latest` before being pushed to DockerHub.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>push-image-to-dockerhub.yml</strong><dd><code>Simplify and streamline Docker image push workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/push-image-to-dockerhub.yml

<li>Renamed job from <code>docker</code> to <code>push</code>.<br> <li> Updated permissions for the job.<br> <li> Consolidated steps for logging in, building, tagging, and pushing <br>Docker images.<br> <li> Removed individual setup steps for QEMU and Buildx.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/52/files#diff-375807204432883d2fe0f02e08e633760f5802823833f872fd5e68d8b0939c6f">+16/-20</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

