### PR TITLE
[PLA-2069] Fixes publish to dockerhub

### DIFF
--- a/.github/workflows/push-image-to-dockerhub.yml
+++ b/.github/workflows/push-image-to-dockerhub.yml
@@ -24,7 +24,7 @@ jobs:
           IMAGE_TAG: ${{ github.ref_name }}
         run: |
           docker login --username $DOCKERHUB_API_USERNAME --password $DOCKERHUB_API_TOKEN
-          docker build -t enjin/$DOCKER_REPOSITORY:$IMAGE_TAG .
+          docker build -t enjin/$DOCKER_REPOSITORY:$IMAGE_TAG -f configs/core/Dockerfile .
           docker push enjin/$DOCKER_REPOSITORY:$IMAGE_TAG
           docker tag enjin/$DOCKER_REPOSITORY:$IMAGE_TAG enjin/$DOCKER_REPOSITORY:latest
           docker push enjin/$DOCKER_REPOSITORY:latest


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the GitHub Actions workflow to specify the Dockerfile location during the Docker image build process.
- This change ensures that the correct Dockerfile is used by adding `-f configs/core/Dockerfile` to the build command.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>push-image-to-dockerhub.yml</strong><dd><code>Specify Dockerfile location in Docker build command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/push-image-to-dockerhub.yml

<li>Modified the Docker build command to specify a Dockerfile location.<br> <li> Added <code>-f configs/core/Dockerfile</code> to the build command.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform/pull/54/files#diff-375807204432883d2fe0f02e08e633760f5802823833f872fd5e68d8b0939c6f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information